### PR TITLE
Sync keccak_permutation_stark with plonky2 implementation

### DIFF
--- a/hashes/keccak_ctl/src/keccak_permutation/columns.rs
+++ b/hashes/keccak_ctl/src/keccak_permutation/columns.rs
@@ -9,10 +9,6 @@ pub const fn reg_step(i: usize) -> usize {
     i
 }
 
-/// A register which indicates if a row should be included in the CTL. Should be 1 only for certain
-/// rows which are final steps, i.e. with `reg_step(23) = 1`.
-pub const REG_FILTER: usize = NUM_ROUNDS;
-
 /// Registers to hold permutation inputs.
 /// `reg_input_limb(2*i) -> input[i] as u32`
 /// `reg_input_limb(2*i+1) -> input[i] >> 32`
@@ -52,7 +48,7 @@ const R: [[u8; 5]; 5] = [
     [27, 20, 39, 8, 14],
 ];
 
-const START_PREIMAGE: usize = NUM_ROUNDS + 1;
+const START_PREIMAGE: usize = NUM_ROUNDS;
 /// Registers to hold the original input to a permutation, i.e. the input to the first round.
 pub(crate) const fn reg_preimage(x: usize, y: usize) -> usize {
     debug_assert!(x < 5);

--- a/hashes/keccak_ctl/src/keccak_permutation/ctl.rs
+++ b/hashes/keccak_ctl/src/keccak_permutation/ctl.rs
@@ -3,8 +3,8 @@ use plonky2_field::types::Field;
 use starky_ctl::cross_table_lookup::Column;
 
 use super::{
-    columns::{reg_input_limb, reg_output_limb, REG_FILTER},
-    keccak_permutation_stark::NUM_INPUTS,
+    columns::{reg_input_limb, reg_output_limb, reg_step},
+    keccak_permutation_stark::{NUM_INPUTS, NUM_ROUNDS},
 };
 
 pub fn ctl_data<F: Field>() -> Vec<Column<F>> {
@@ -14,6 +14,6 @@ pub fn ctl_data<F: Field>() -> Vec<Column<F>> {
 }
 
 pub fn ctl_filter<F: Field>() -> Column<F> {
-    let res = Column::single(REG_FILTER);
+    let res = Column::single(reg_step(NUM_ROUNDS - 1));
     res
 }

--- a/hashes/keccak_ctl/src/keccak_permutation/keccak_permutation_stark.rs
+++ b/hashes/keccak_ctl/src/keccak_permutation/keccak_permutation_stark.rs
@@ -12,7 +12,7 @@ use plonky2::util::timing::TimingTree;
 
 use crate::keccak_permutation::columns::{
     reg_a, reg_a_prime, reg_a_prime_prime, reg_a_prime_prime_0_0_bit, reg_a_prime_prime_prime,
-    reg_b, reg_c, reg_c_prime, reg_preimage, reg_step, NUM_COLUMNS, REG_FILTER,
+    reg_b, reg_c, reg_c_prime, reg_preimage, reg_step, NUM_COLUMNS,
 };
 use crate::keccak_permutation::constants::{rc_value, rc_value_bit};
 use crate::keccak_permutation::logic::{
@@ -46,19 +46,16 @@ impl<F: RichField + Extendable<D>, const D: usize> KeccakPermutationStark<F, D> 
         let num_rows = (inputs.len() * NUM_ROUNDS)
             .max(min_rows)
             .next_power_of_two();
+
         let mut rows = Vec::with_capacity(num_rows);
         for input in inputs.iter() {
-            let mut rows_for_perm = self.generate_trace_rows_for_perm(*input);
-            // Since this is a real operation, not padding, we set the filter to 1 on the last row.
-            rows_for_perm[NUM_ROUNDS - 1][REG_FILTER] = F::ONE;
+            let rows_for_perm = self.generate_trace_rows_for_perm(*input);
             rows.extend(rows_for_perm);
         }
 
-        let pad_rows = self.generate_trace_rows_for_perm([0; NUM_INPUTS]);
         while rows.len() < num_rows {
-            rows.extend(&pad_rows);
+            rows.push([F::ZERO; NUM_COLUMNS]);
         }
-        rows.drain(num_rows..);
         rows
     }
 
@@ -244,7 +241,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakPermuta
         eval_round_flags(vars, yield_constr);
 
         // The filter must be 0 or 1.
-        let filter = vars.local_values[REG_FILTER];
+        let filter = vars.local_values[reg_step(NUM_ROUNDS - 1)];
         yield_constr.constraint(filter * (filter - P::ONES));
 
         // If this is not the final step, the filter must be off.
@@ -253,11 +250,25 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakPermuta
         yield_constr.constraint(not_final_step * filter);
 
         // If this is not the final step, the local and next preimages must match.
+        // Also, if this is the first step, the preimage must match A.
+        let is_first_step = vars.local_values[reg_step(0)];
         for x in 0..5 {
             for y in 0..5 {
-                let preimage = reg_preimage(x, y);
-                let diff = vars.local_values[preimage] - vars.next_values[preimage];
-                yield_constr.constraint_transition(not_final_step * diff);
+                let reg_preimage_lo = reg_preimage(x, y);
+                let reg_preimage_hi = reg_preimage_lo + 1;
+                let diff_lo =
+                    vars.local_values[reg_preimage_lo] - vars.next_values[reg_preimage_lo];
+                let diff_hi =
+                    vars.local_values[reg_preimage_hi] - vars.next_values[reg_preimage_hi];
+                yield_constr.constraint_transition(not_final_step * diff_lo);
+                yield_constr.constraint_transition(not_final_step * diff_hi);
+
+                let reg_a_lo = reg_a(x, y);
+                let reg_a_hi = reg_a_lo + 1;
+                let diff_lo = vars.local_values[reg_preimage_lo] - vars.local_values[reg_a_lo];
+                let diff_hi = vars.local_values[reg_preimage_hi] - vars.local_values[reg_a_hi];
+                yield_constr.constraint(is_first_step * diff_lo);
+                yield_constr.constraint(is_first_step * diff_hi);
             }
         }
 
@@ -412,7 +423,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakPermuta
         eval_round_flags_recursively(builder, vars, yield_constr);
 
         // The filter must be 0 or 1.
-        let filter = vars.local_values[REG_FILTER];
+        let filter = vars.local_values[reg_step(NUM_ROUNDS - 1)];
         let constraint = builder.mul_sub_extension(filter, filter, filter);
         yield_constr.constraint(builder, constraint);
 
@@ -423,13 +434,39 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakPermuta
         yield_constr.constraint(builder, constraint);
 
         // If this is not the final step, the local and next preimages must match.
+        // Also, if this is the first step, the preimage must match A.
+        let is_first_step = vars.local_values[reg_step(0)];
         for x in 0..5 {
             for y in 0..5 {
-                let preimage = reg_preimage(x, y);
-                let diff =
-                    builder.sub_extension(vars.local_values[preimage], vars.next_values[preimage]);
+                let reg_preimage_lo = reg_preimage(x, y);
+                let reg_preimage_hi = reg_preimage_lo + 1;
+                let diff = builder.sub_extension(
+                    vars.local_values[reg_preimage_lo],
+                    vars.next_values[reg_preimage_lo],
+                );
                 let constraint = builder.mul_extension(not_final_step, diff);
                 yield_constr.constraint_transition(builder, constraint);
+                let diff = builder.sub_extension(
+                    vars.local_values[reg_preimage_hi],
+                    vars.next_values[reg_preimage_hi],
+                );
+                let constraint = builder.mul_extension(not_final_step, diff);
+                yield_constr.constraint_transition(builder, constraint);
+
+                let reg_a_lo = reg_a(x, y);
+                let reg_a_hi = reg_a_lo + 1;
+                let diff_lo = builder.sub_extension(
+                    vars.local_values[reg_preimage_lo],
+                    vars.local_values[reg_a_lo],
+                );
+                let constraint = builder.mul_extension(is_first_step, diff_lo);
+                yield_constr.constraint(builder, constraint);
+                let diff_hi = builder.sub_extension(
+                    vars.local_values[reg_preimage_hi],
+                    vars.local_values[reg_a_hi],
+                );
+                let constraint = builder.mul_extension(is_first_step, diff_hi);
+                yield_constr.constraint(builder, constraint);
             }
         }
 


### PR DESCRIPTION
There have been a few upstream updates recently that add missing constraints and remove unnecessary columns to the starky keccak implementation

Ref: https://github.com/mir-protocol/plonky2/commits/main/evm/src/keccak/keccak_stark.rs